### PR TITLE
Hotfix for `rai version -p .` crash

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,9 +91,11 @@ func Execute() error {
 var VersionCmd = cmd.VersionCmd
 
 func init() {
+	// Store the original run function so we can explicitly run it later
+	var original_VersionCmd_run = VersionCmd.Run
 	// The version information command
 	VersionCmd.Run = func(c *cobra.Command, args []string) {
-		cmd.VersionCmd.Run(c, args)
+		original_VersionCmd_run(c, args)
 		if ece408ProjectMode {
 			fmt.Println("ECE408ProjectMode: ", ece408ProjectMode)
 		}


### PR DESCRIPTION
VersionCmd in `cmd/root.go` is a reference to cobra command cmd.VersionCmd. In the init function, the Run value is assigned to a new function that calls itself until stack overflows.

I think the intention here is to call the original `cmd.VersionCmd.Run` and add some checking (more like append/update to the original value). But `cmd.VersionCmd.Run` is just a symbol when it is compiled, since Go is not a dynamic language.

My fix is to assign a new variable (or function pointer) for the original `cmd.VersionCmd.Run` and explicitly run it inside the new one.

With this fix, it no longer crashes when running `rai version -p .` and I was able to get the following output:
```
wei@MSI-7A69 ~/go/src/github.com/weiren2/rai (git)-[rai-version-hotfix] % ./rai version -p .
BuildDate:  2019-04-24T20:19:42Z
GitCommit:  903f905
GitBranch:  rai-version-hotfix
GitState:  dirty
GitSummary:  class_v0.7.1-dirty
```